### PR TITLE
feat: add frontend hand control interface

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,10 +1,12 @@
 import express from "express";
 import bluetoothService from "./services/BluetoothService.js";
 import { validateCommand } from "./services/commandValidator.js";
+import cors from "cors";
 
 const app = express();
 const PORT = 3001;
 
+app.use(cors());
 app.use(express.json());
 
 // Health check route

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "yeah-hand-web-app",
       "version": "0.0.0",
       "dependencies": {
+        "cors": "^2.8.6",
         "express": "^5.2.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -2337,6 +2338,23 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3437,6 +3455,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "cors": "^2.8.6",
     "express": "^5.2.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,87 @@
+import { useState } from "react";
+
 function App() {
+    const [status, setStatus] = useState("Not Connected");
+    const [command, setCommand] = useState("PINCH 50");
+
+    async function connectHand() {
+        try {
+            const response = await fetch("http://localhost:3001/api/hand/connect", {
+                method: "POST",
+            });
+
+            const data = await response.json();
+
+            setStatus(data.message);
+        } catch {
+            setStatus("Connection failed");
+        }
+    }
+
+    async function sendCommand() {
+        try {
+            const response = await fetch("http://localhost:3001/api/hand/command", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    command,
+                }),
+            });
+
+            const data = await response.json();
+
+            setStatus(data.message || data.error);
+        } catch {
+            setStatus("Command failed");
+        }
+    }
+
+    async function disconnectHand() {
+        try {
+            const response = await fetch("http://localhost:3001/api/hand/disconnect", {
+                method: "POST",
+            });
+
+            const data = await response.json();
+
+            setStatus(data.message);
+        } catch {
+            setStatus("Disconnect failed");
+        }
+    }
+
     return (
         <div style={{ padding: "2rem", fontFamily: "sans-serif" }}>
             <h1>Yeah Hand Control Interface</h1>
-            <p>Status: Not Connected</p>
+
+            <p>Status: {status}</p>
+
+            <div style={{ display: "flex", gap: "1rem" }}>
+                <input
+                    type="text"
+                    value={command}
+                    onChange={(e) => setCommand(e.target.value)}
+                    placeholder="Enter command"
+                    style={{
+                        padding: "0.5rem",
+                        marginBottom: "1rem",
+                        width: "300px",
+                    }}
+                />
+                <button onClick={connectHand}>
+                    Connect
+                </button>
+
+                <button onClick={sendCommand}>
+                    Send Command
+                </button>
+
+                <button onClick={disconnectHand}>
+                    Disconnect
+                </button>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary

* Added initial frontend control interface for the Yeah Hand system
* Added Connect and Disconnect controls
* Added dynamic command input field
* Added Send Command functionality
* Added frontend status/error display
* Connected frontend to backend API endpoints
* Added CORS support for frontend/backend communication

## Testing

Tested locally through the complete simulated flow:

* Connect to backend API
* Send valid commands (`PINCH 50`, `POWER 100`)
* Reject invalid commands (`BANANA 999`)
* Disconnect successfully

## Notes

The frontend currently communicates with the simulated backend Bluetooth service while hardware integration is still in progress.

This PR establishes the first complete browser → backend → Bluetooth service command flow for the project.
