### PR TITLE
feat: send commands directly from control buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ function App() {
         }
     }
 
-    async function sendCommand() {
+    async function sendCommand(commandToSend = command) {
         try {
             const response = await fetch("http://localhost:3001/api/hand/command", {
                 method: "POST",
@@ -79,19 +79,19 @@ function App() {
                 Status: {status}
             </p>
             <div style={{ display: "flex", gap: "1rem", marginBottom: "1rem" }}>
-                <button onClick={() => setCommand("PINCH 50")}>
+                <button onClick={() => sendCommand("PINCH 50")}>
                     PINCH
                 </button>
 
-                <button onClick={() => setCommand("POWER 100")}>
+                <button onClick={() => sendCommand("POWER 100")}>
                     POWER
                 </button>
 
-                <button onClick={() => setCommand("MONKEY 25")}>
+                <button onClick={() => sendCommand("MONKEY 25")}>
                     MONKEY
                 </button>
 
-                <button onClick={() => setCommand("RELAX")}>
+                <button onClick={() => sendCommand("RELAX")}>
                     RELAX
                 </button>
             </div>


### PR DESCRIPTION
## Summary

This PR improves the frontend control interface by allowing predefined gesture buttons to send commands directly to the backend API instead of only updating the command input field.

## Changes

- Updated `sendCommand()` to accept an optional command parameter.
- Modified gesture buttons to send commands immediately when clicked.
- Preserved support for custom commands entered through the input field.
- Improved the command flow between the React frontend and Express backend.

## Testing

- Started frontend with `npm run dev`
- Started backend with `node backend/server.js`
- Verified successful connection to the simulated Bluetooth service
- Confirmed predefined gesture buttons send commands directly to the backend
- Verified backend logs commands such as `PINCH 50`