### PR TITLE
fix: use commandToSend in sendCommand

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,12 +26,12 @@ function App() {
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
-                    command,
+                    command: commandToSend,
                 }),
             });
 
             const data = await response.json();
-            const commandLabel = command.split(" ")[0];
+            const commandLabel = commandToSend.split(" ")[0];
 
             setStatus(
                 data.success
@@ -112,7 +112,7 @@ function App() {
                     Connect
                 </button>
 
-                <button onClick={sendCommand}>
+                <button onClick={() => sendCommand()}>
                     Send Command
                 </button>
 


### PR DESCRIPTION
## Summary

Fixes `sendCommand` so both the preset control buttons and the manual Send Command button behave correctly.

### Changes

- Uses `commandToSend` in the request body
- Uses `commandToSend` for the status label
- Wraps the manual Send Command button handler to avoid passing the click event

Closes #13