### PR TITLE
fix: update command protocol to separate gestures and factors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project has two main layers:
 - Written in C/C++
 - Runs on the ESP32 inside the robotic hand
 - Controls the motors/fingers
-- Receives command strings such as `PINCH 50`
+- Receives gesture and factor commands separately, such as `PINCH` followed by `50`
 
 ### Web/backend layer
 - Written in JavaScript/TypeScript
@@ -33,12 +33,10 @@ Before getting started, make sure you have the following installed:
 
 ### Backend Setup
 
-From the project root, install the backend dependencies:
+The frontend and backend share the root `package.json`. From the project root, install all dependencies:
 
 ```bash
-cd backend
 npm install
-cd ..
 ```
 
 Start the backend server from the project root:
@@ -60,7 +58,8 @@ node backend/test/bluetoothTest.js
 ```text
 Connecting to Bluetooth device...
 Simulated Bluetooth connection established.
-Sending command to hand: PINCH 50
+Sending command to hand: PINCH
+Sending command to hand: 50
 Disconnecting from Bluetooth device...
 Bluetooth connection closed.
 ```

--- a/backend/services/commandValidator.js
+++ b/backend/services/commandValidator.js
@@ -14,36 +14,30 @@ export function validateCommand(command) {
         };
     }
 
-    const parts = command.trim().split(/\s+/);
+    const trimmedCommand = command.trim();
 
-    const commandName = parts[0];
-    const closureValue = parts[1];
-
-    // Validate command name
-    if (!VALID_COMMANDS.includes(commandName)) {
+    // Accept gesture commands by themselves
+    if (VALID_COMMANDS.includes(trimmedCommand)) {
         return {
-            valid: false,
-            error: `Invalid command: ${commandName}`,
+            valid: true,
         };
     }
 
-    // Validate optional closure percentage
-    if (closureValue !== undefined) {
-        const closureNumber = Number(closureValue);
+    // Accept factor values by themselves
+    const factor = Number(trimmedCommand);
 
-        if (
-            !Number.isInteger(closureNumber) ||
-            closureNumber < 0 ||
-            closureNumber > 100
-        ) {
-            return {
-                valid: false,
-                error: "Closure value must be an integer between 0 and 100.",
-            };
-        }
+    if (
+        Number.isInteger(factor) &&
+        factor >= 0 &&
+        factor <= 100
+    ) {
+        return {
+            valid: true,
+        };
     }
 
     return {
-        valid: true,
+        valid: false,
+        error: "Command must be a valid gesture or an integer between 0 and 100.",
     };
 }

--- a/backend/test/bluetoothTest.js
+++ b/backend/test/bluetoothTest.js
@@ -2,7 +2,8 @@ import bluetoothService from "../services/BluetoothService.js";
 try {
     bluetoothService.connect();
 
-    bluetoothService.sendCommand("PINCH 50");
+    bluetoothService.sendCommand("PINCH");
+    bluetoothService.sendCommand("50");
 
     bluetoothService.disconnect();
 } catch (error) {

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,24 @@
+# Engineering Decisions
+
+Purpose:
+Document important technical decisions and why they were made.
+
+Include the reasoning so future contributors understand the context.
+# Command Protocol
+
+Decision
+
+Gesture and factor are sent separately.
+
+Reason
+
+Requested by Vittorio on July 3.
+
+Old
+
+PINCH 50
+
+New
+
+PINCH
+50

--- a/docs/DEV_LOG.md
+++ b/docs/DEV_LOG.md
@@ -1,0 +1,36 @@
+# Development Log
+
+Purpose:
+Record each development session, what was completed, blockers encountered, lessons learned, and the next steps.
+
+Add a new entry for every work session.
+# July 17, 2026
+
+Time
+2:30 PM - 5:00 PM
+
+Goal
+
+Implement webcam streaming.
+
+Completed
+
+- Reviewed backend architecture.
+- Found where video endpoint should live.
+- Added Project Status document.
+
+Issues
+
+Need to determine whether Vittorio wants MJPEG or WebRTC.
+
+Next Session
+
+Implement backend video route.
+
+Commit
+
+abc1234
+
+PR
+
+#17

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -1,0 +1,17 @@
+
+# Future Ideas
+
+Purpose:
+Capture future improvements and feature ideas without interrupting current work.
+
+Ideas here are not commitments—they're simply possibilities for later evaluation.
+Future Idea
+
+
+Ex:
+
+Virtual joystick.
+
+Reason
+
+Easier than buttons on mobile.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,0 +1,188 @@
+# Yeah Hand - Project Status
+
+**Last Updated:** July 17, 2026
+
+
+
+Purpose:
+This document always reflects the CURRENT state of the project. Update it whenever priorities, milestones, or project status change.
+
+Do NOT keep historical information here—that belongs in DEV_LOG.md.
+
+
+---
+
+# Project Overview
+
+The goal of this project is to create a web application that allows users to remotely control the Yeah Robotic/Prosthetic Hand.
+
+Current architecture:
+
+Browser
+↓
+React Frontend
+↓
+Express Backend
+↓
+Bluetooth Service
+↓
+Yeah Hand Hardware
+
+The backend also streams webcam video to the frontend.
+
+---
+
+# Repository
+
+Repository:
+PubInv/Yeah-Hand-Web-App
+
+Current Branch:
+
+GoodKimchi/____________________
+
+Main Maintainer:
+
+Vittorio Lumare
+
+---
+
+# Completed
+
+## Backend
+
+- [x] Express backend
+- [x] BluetoothService simulation
+- [x] Connect endpoint
+- [x] Command endpoint
+- [x] Disconnect endpoint
+
+## Frontend
+
+- [x] Connect button
+- [x] Disconnect button
+- [x] Command buttons
+- [x] Status display
+
+## Documentation
+
+- [x] Backend setup guide
+- [x] Frontend setup guide
+- [x] Bluetooth test guide
+
+## Protocol
+
+- [x] Updated command protocol
+- [x] Gesture commands separated from factor values
+
+---
+
+# Current Protocol
+
+Gesture:
+
+PINCH
+
+POWER
+
+MONKEY
+
+RELAX
+
+Factor:
+
+0
+
+15
+
+40
+
+100
+
+Gesture and factor are sent separately.
+
+---
+
+# Hardware Status
+
+- [x] Hand received
+- [x] Parts received
+- [ ] Assemble hand
+- [ ] Connect Bluetooth
+- [ ] Test first movement
+
+---
+
+# Current Priority
+
+1. Webcam streaming
+2. Assemble hand
+3. Bluetooth integration
+4. Hardware testing
+5. Backend unit tests
+
+---
+
+# Important Files
+
+Frontend
+
+src/App.tsx
+
+Backend
+
+backend/server.js
+
+backend/services/BluetoothService.js
+
+backend/services/commandValidator.js
+
+Documentation
+
+README.md
+
+docs/bluetooth-command-protocol.md
+
+---
+
+# Pull Requests
+
+Merged
+
+-
+
+Open
+
+-
+
+---
+
+# Things I Learned
+
+(Add notes after every coding session.)
+
+---
+
+# Questions for Vittorio
+
+(Add anything that needs clarification.)
+
+---
+
+# Session Log
+
+## July 17
+
+Completed
+
+- Updated command protocol
+- Opened PR #16
+
+Next Session
+
+- Webcam streaming
+- Assemble hand
+
+Notes
+
+- Vittorio wants webcam before Bluetooth.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -28,7 +28,7 @@ Bluetooth Service
 ↓
 Yeah Hand Hardware
 
-The backend also streams webcam video to the frontend.
+Webcam streaming from the backend to the frontend is planned but not yet implemented.
 
 ---
 
@@ -39,7 +39,7 @@ PubInv/Yeah-Hand-Web-App
 
 Current Branch:
 
-GoodKimchi/____________________
+oscar/update-command-protocol
 
 Main Maintainer:
 
@@ -85,19 +85,15 @@ PINCH
 
 POWER
 
+POWERSMALL
+
 MONKEY
 
 RELAX
 
 Factor:
 
-0
-
-15
-
-40
-
-100
+Any integer from 0 through 100.
 
 Gesture and factor are sent separately.
 

--- a/docs/QUESTIONS_FOR_VITTORIO.md
+++ b/docs/QUESTIONS_FOR_VITTORIO.md
@@ -1,0 +1,13 @@
+# Questions for Vittorio
+
+Purpose:
+Keep track of open questions for Vittorio.
+
+Once a question is answered, remove it or move the decision into DECISIONS.md.
+
+ex:
+- Should webcam stream use MJPEG or WebRTC?
+
+- Should Bluetooth reconnect automatically?
+
+- Should backend queue commands?

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 function App() {
     const [status, setStatus] = useState("Not Connected");
-    const [command, setCommand] = useState("PINCH 50");
+    const [command, setCommand] = useState("PINCH");
 
     async function connectHand() {
         try {
@@ -31,11 +31,9 @@ function App() {
             });
 
             const data = await response.json();
-            const commandLabel = commandToSend.split(" ")[0];
-
             setStatus(
                 data.success
-                    ? `Sent ${commandLabel}`
+                    ? `Sent ${commandToSend}`
                     : data.error
             );
         } catch {
@@ -79,15 +77,15 @@ function App() {
                 Status: {status}
             </p>
             <div style={{ display: "flex", gap: "1rem", marginBottom: "1rem" }}>
-                <button onClick={() => sendCommand("PINCH 50")}>
+                <button onClick={() => sendCommand("PINCH")}>
                     PINCH
                 </button>
 
-                <button onClick={() => sendCommand("POWER 100")}>
+                <button onClick={() => sendCommand("POWER")}>
                     POWER
                 </button>
 
-                <button onClick={() => sendCommand("MONKEY 25")}>
+                <button onClick={() => sendCommand("MONKEY")}>
                     MONKEY
                 </button>
 


### PR DESCRIPTION
## Summary

Updates the frontend and backend to match the current Yeah Hand command protocol.

### Changes
- Updated frontend buttons to send gesture commands independently (`PINCH`, `POWER`, `MONKEY`, `RELAX`).
- Updated backend validation to accept standalone gesture commands and numeric factor values (`0–100`).
- Updated command handling to match the current protocol, where gesture commands and factor values are sent separately.
### Testing
- Verified gesture commands are accepted.
- Verified standalone numeric values (`0–100`) are accepted.
- Verified combined commands (e.g. `PINCH 50`) are rejected.
- Verified out-of-range values (e.g. `101`) are rejected.